### PR TITLE
Delete vault-infra-sol workspace

### DIFF
--- a/data/browningluke/workspaces.yml
+++ b/data/browningluke/workspaces.yml
@@ -101,20 +101,6 @@
       - "/terraform/sol-vault/**"
       - "/terraform/_modules/**"
 
-- name: vault-infra-sol-vault
-  description: ""
-  project: homelab
-  thing: null
-  execution_mode: remote
-  tags: ['vault', 'meta']
-  vcs:
-    repo: "browningluke-iac/vault-infra"
-    working_dir: "terraform/sol-vault"
-    trigger_patterns:
-      - "/data/sol-vault/**"
-      - "/terraform/sol-vault/**"
-      - "/terraform/_modules/**"
-
 # ==== PVE ====
 - name: pve-lxc-sol-pihole
   description: ""


### PR DESCRIPTION
`sol-vault` hosted on `sol-k8s` cluster now. Therefore there is no infra specifically for vault.